### PR TITLE
adding version tag to gcr minikube image so that packer can build AMI

### DIFF
--- a/toolsets/toolset-2004.json
+++ b/toolsets/toolset-2004.json
@@ -164,7 +164,7 @@
             "ubuntu:20.04",
             "namely/protoc-all:latest",
             "gcr.io/k8s-minikube/storage-provisioner:v5",
-            "gcr.io/k8s-minikube/kicbase"
+            "gcr.io/k8s-minikube/kicbase:v0.0.32"
         ]
     },
     "pipx": [


### PR DESCRIPTION
Description
---
Github runner was failing due to image not being found. I added the lates image tag that is in the gcr. That particular error should not appear.