### PR TITLE
updating the name of the AMI that is used so that unique AMIs are generated for each cron run

### DIFF
--- a/aws-ubuntu2004.json
+++ b/aws-ubuntu2004.json
@@ -47,7 +47,7 @@
                 "most_recent": true
             },
             "instance_type": "m5.xlarge",
-            "ami_name": "github-runner-focal",
+            "ami_name": "github-runner-focal-{{strftime \"%m-%d-%Y-%H:%M\"}}",
             "force_deregister": true,
             "force_delete_snapshot": true,
             "ami_regions": [


### PR DESCRIPTION
Description
--- 
There is currently an action in the meroxa/infra repo that generates a new runner AMI each night. The problem that occurs when doing this is that it replaces the older AMIs that were created because the names are not unique. This PR is apart of the work needed for meroxa/infra#668

Work Done
---
This PR addresses this issue by adding a timestamp value to the packer build so that the names are now unique, addressed by a timestamp